### PR TITLE
Fix for issue #25:  Do not create two FlutterViewControllers 

### DIFF
--- a/macos/Classes/MacOSWindowUtilsViewController.swift
+++ b/macos/Classes/MacOSWindowUtilsViewController.swift
@@ -9,11 +9,11 @@ import Foundation
 import FlutterMacOS
 
 public class MacOSWindowUtilsViewController: NSViewController {
-    public var flutterViewController = FlutterViewController()
+    public var flutterViewController : FlutterViewController? = nil;
     private var visualEffectSubviewRegistry = VisualEffectSubviewRegistry()
 
     public init(flutterViewController: FlutterViewController? = nil) {
-        self.flutterViewController = flutterViewController ?? self.flutterViewController
+        self.flutterViewController = flutterViewController ?? FlutterViewController()
         
         super.init(nibName: nil, bundle: nil)
     }
@@ -36,19 +36,19 @@ public class MacOSWindowUtilsViewController: NSViewController {
     override public func viewDidLoad() {
         super.viewDidLoad()
 
-        self.addChild(flutterViewController)
+        self.addChild(flutterViewController!)
 
-        flutterViewController.view.frame = self.view.bounds
-        flutterViewController.view.autoresizingMask = [.width, .height]
+        flutterViewController!.view.frame = self.view.bounds
+        flutterViewController!.view.autoresizingMask = [.width, .height]
         
         // Since Flutter 3.7.0 the FlutterViewController's background is black by default and therefore needs to be set to clear.
-        flutterViewController.backgroundColor = .clear
+        flutterViewController!.backgroundColor = .clear
         
-        self.view.addSubview(flutterViewController.view)
+        self.view.addSubview(flutterViewController!.view)
     }
     
     public func addVisualEffectSubview(_ visualEffectSubview: VisualEffectSubview) -> UInt {
-        self.view.addSubview(visualEffectSubview, positioned: .below, relativeTo: flutterViewController.view)
+        self.view.addSubview(visualEffectSubview, positioned: .below, relativeTo: flutterViewController!.view)
         return visualEffectSubviewRegistry.registerSubview(visualEffectSubview)
     }
     


### PR DESCRIPTION
Issue: creating another instance of `FlutterViewController` in `MacOSWindowUtilsViewController`

Creating two instances of `FlutterViewController` does not allow the app to close in the newer Flutter versions and keeps the program open ( issue #25 ). Instead of initializing at class level, check whether a FVC is given first and then create one. 

I cannot test the examples on 3.10 due to `macos_ui` currently not supporting 3.10 (which will soon be fixed from what is looks like). But I checked it in 3.7.12. I can run the fixed code on 3.10 using `flutter_acrylic` and it resolves the issue of not closing.