### PR TITLE
Version 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.7.1
+- Fix nil being found when unwrapping an Optional value when `reset` is called before `start` in `MainFlutterWindowManipulator.swift`.
+
 ## 1.7.0
 - Add `MacosToolbarPassthrough` to allow for the creation of so-called “passthrough views” on the toolbar that relay mouse events to the Flutter application (thanks to [@Andre-lbc](https://github.com/Andre-lbc) and [@adiletcool](https://github.com/adiletcool)).
 

--- a/macos/Classes/MainFlutterWindowManipulator.swift
+++ b/macos/Classes/MainFlutterWindowManipulator.swift
@@ -48,6 +48,11 @@ public class MainFlutterWindowManipulator {
     }
     
     public static func reset() {
+        if (self.mainFlutterWindow == nil) {
+            start(mainFlutterWindow: nil)
+            return;
+        }
+        
         passthroughViewHandler.start(mainFlutterWindow: self.mainFlutterWindow!)
     }
     

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: macos_window_utils
 description:
   macos_window_utils is a Flutter package that provides a set of methods for
   modifying the NSWindow of a Flutter application on macOS.
-version: 1.7.0
+version: 1.7.1
 repository: https://github.com/Adrian-Samoticha/macos_window_utils.dart
 
 environment:


### PR DESCRIPTION
Fix nil being found when unwrapping an Optional value when `reset` is called before `start` in `MainFlutterWindowManipulator.swift`.

This PR resolves #59.